### PR TITLE
chore: adding Unity Catalog IO Manager CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install pypa/build
       run: make .venv && VIRTUAL_ENV=./.venv 
     - name: Build a binary wheel
-      run: source .venv/bin/activate && python3 -m build -w "libraries/dagster-delta" && python3 -m build -w "libraries/dagster-delta-polars"
+      run: source .venv/bin/activate && python3 -m build -w "libraries/dagster-delta" && python3 -m build -w "libraries/dagster-delta-polars" && python3 -m build -w "libraries/dagster-unity-catalog-polars"
     - name: Store the distribution packages
       uses: actions/upload-artifact@v3
       with:
@@ -116,6 +116,32 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: my_dists/dagster-delta-polars/dist/
+        password: ${{ secrets.PYPI_API_TOKEN_DDP }}
+        verbose: true
+
+  publish-dagster-unity-catalog-polars:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dagster-unity-catalog-polars
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: my_dists/
+    - name: list files
+      run: ls my_dists/dagster-unity-catalog-polars/dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: my_dists/dagster-unity-catalog-polars/dist/
         password: ${{ secrets.PYPI_API_TOKEN_DDP }}
         verbose: true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -142,6 +142,6 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: my_dists/dagster-unity-catalog-polars/dist/
-        password: ${{ secrets.PYPI_API_TOKEN_DDP }}
+        password: ${{ secrets.PYPI_API_TOKEN_DDUC }}
         verbose: true
 


### PR DESCRIPTION
Added building the wheel and publishing to PyPi for the Dagster Unity Catalog IO Manager CI workflow