### PR TITLE
refactor: delta, delta-polars

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: "3.9"
     - name: Install pypa/build
-      run: make .venv && VIRTUAL_ENV=./.venv 
+      run: pip install uv && make .venv && VIRTUAL_ENV=./.venv 
     - name: CI-check
       run: source .venv/bin/activate && make ci-check
     
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: "3.9"
     - name: Install pypa/build
-      run: make .venv && VIRTUAL_ENV=./.venv 
+      run: pip install uv && make .venv && VIRTUAL_ENV=./.venv 
     - name: Execute tests
       run: source .venv/bin/activate && pytest .
 
@@ -57,7 +57,7 @@ jobs:
       with:
         python-version: "3.9"
     - name: Install pypa/build
-      run: make .venv && VIRTUAL_ENV=./.venv 
+      run: pip install uv && make .venv && VIRTUAL_ENV=./.venv 
     - name: Build a binary wheel
       run: source .venv/bin/activate && python3 -m build -w "libraries/dagster-delta" && python3 -m build -w "libraries/dagster-delta-polars" && python3 -m build -w "libraries/dagster-unity-catalog-polars"
     - name: Store the distribution packages

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ else
 endif
 
 .venv:  ## Set up virtual environment and install requirements
-	pip3 install uv==0.2.35
 	uv venv
 	$(MAKE) requirements
 

--- a/libraries/dagster-delta-polars/pyproject.toml
+++ b/libraries/dagster-delta-polars/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "dagster-delta-polars"
-version = "0.1.5"
+version = "0.2.0"
 description = "Polars deltalake IO Managers for Dagster with optional LakeFS support"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "dagster-delta"
+    "dagster-delta",
+    "Deprecated",
 ]
 authors = [
     {name = "Ion Koutsouris", email = "15728914+ion-elgreco@users.noreply.github.com"},

--- a/libraries/dagster-delta/dagster_delta/dbiomanager_fixed.py
+++ b/libraries/dagster-delta/dagster_delta/dbiomanager_fixed.py
@@ -25,7 +25,7 @@ class DbIOManagerFixed(DbIOManager):  # noqa
         context: Union[OutputContext, InputContext],  # noqa
         output_context: OutputContext,
     ) -> TableSlice:
-        output_context_metadata = output_context.metadata or {}
+        output_context_definition_metadata = output_context.definition_metadata or {}
 
         schema: str
         table: str
@@ -33,13 +33,13 @@ class DbIOManagerFixed(DbIOManager):  # noqa
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
 
-            if output_context_metadata.get("root_name"):
-                table = output_context_metadata["root_name"]
+            if output_context_definition_metadata.get("root_name"):
+                table = output_context_definition_metadata["root_name"]
             else:
                 table = asset_key_path[-1]
             # schema order of precedence: metadata, I/O manager 'schema' config, key_prefix
-            if output_context_metadata.get("schema"):
-                schema = cast(str, output_context_metadata["schema"])
+            if output_context_definition_metadata.get("schema"):
+                schema = cast(str, output_context_definition_metadata["schema"])
             elif self._schema:
                 schema = self._schema
             elif len(asset_key_path) > 1:
@@ -48,7 +48,7 @@ class DbIOManagerFixed(DbIOManager):  # noqa
                 schema = "public"
 
             if context.has_asset_partitions:
-                partition_expr = output_context_metadata.get("partition_expr")
+                partition_expr = output_context_definition_metadata.get("partition_expr")
                 if partition_expr is None:
                     raise ValueError(
                         f"Asset '{context.asset_key}' has partitions, but no 'partition_expr'"
@@ -110,8 +110,8 @@ class DbIOManagerFixed(DbIOManager):  # noqa
                     )
         else:
             table = output_context.name
-            if output_context_metadata.get("schema"):
-                schema = cast(str, output_context_metadata["schema"])
+            if output_context_definition_metadata.get("schema"):
+                schema = cast(str, output_context_definition_metadata["schema"])
             elif self._schema:
                 schema = self._schema
             else:
@@ -122,5 +122,5 @@ class DbIOManagerFixed(DbIOManager):  # noqa
             schema=schema,
             database=self._database,
             partition_dimensions=partition_dimensions,
-            columns=(context.metadata or {}).get("columns"),
+            columns=(context.definition_metadata or {}).get("columns"),
         )

--- a/libraries/dagster-delta/dagster_delta/io_manager.py
+++ b/libraries/dagster-delta/dagster_delta/io_manager.py
@@ -81,6 +81,7 @@ class _DeltaTableIOManagerResourceConfig(TypedDict):
     table_config: NotRequired[dict[str, str]]
     custom_metadata: NotRequired[dict[str, str]]
     writer_properties: NotRequired[dict[str, str]]
+    commit_properties: NotRequired[dict[str, str]]
     parquet_read_options: NotRequired[dict[str, Any]]
 
 
@@ -146,7 +147,7 @@ class DeltaLakeIOManager(ConfigurableIOManagerFactory):
         description="If set to 'overwrite', allows replacing the schema of the table. Set to 'merge' to merge with existing schema.",
     )
     writer_engine: WriterEngine = Field(  # type: ignore
-        default=WriterEngine.pyarrow.value,
+        default=WriterEngine.rust.value,
         description="Engine passed to write_deltalake.",
     )
 
@@ -184,6 +185,10 @@ class DeltaLakeIOManager(ConfigurableIOManagerFactory):
         default=None,
         description="Writer properties passed to the rust engine writer.",
     )
+    commit_properties: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Commit properties, Controls the behaviour of the commit.",
+    )
     parquet_read_options: Optional[dict[str, Any]] = Field(
         default=None,
         description="Parquet read options, to be passed to pyarrow.",
@@ -199,7 +204,7 @@ class DeltaLakeIOManager(ConfigurableIOManagerFactory):
         return None
 
     def create_io_manager(self, context) -> DbIOManager:  # noqa: D102, ANN001, ARG002
-        self.storage_options.dict()
+        self.storage_options.model_dump()
         return DbIOManagerFixed(
             db_client=DeltaLakeDbClient(),
             database="deltalake",

--- a/libraries/dagster-delta/dagster_delta_tests/test_delta_table_resource.py
+++ b/libraries/dagster-delta/dagster_delta_tests/test_delta_table_resource.py
@@ -18,7 +18,11 @@ def test_resource(tmp_path):
 
     @asset
     def create_table(delta_table: DeltaTableResource):
-        write_deltalake(delta_table.url, data, storage_options=delta_table.storage_options.dict())
+        write_deltalake(
+            delta_table.url,
+            data,
+            storage_options=delta_table.storage_options.model_dump(),
+        )
 
     @asset
     def read_table(delta_table: DeltaTableResource):
@@ -46,11 +50,15 @@ def test_resource_versioned(tmp_path):
 
     @asset
     def create_table(delta_table: DeltaTableResource):
-        write_deltalake(delta_table.url, data, storage_options=delta_table.storage_options.dict())
         write_deltalake(
             delta_table.url,
             data,
-            storage_options=delta_table.storage_options.dict(),
+            storage_options=delta_table.storage_options.model_dump(),
+        )
+        write_deltalake(
+            delta_table.url,
+            data,
+            storage_options=delta_table.storage_options.model_dump(),
             mode="append",
         )
 

--- a/libraries/dagster-delta/dagster_delta_tests/test_metadata_inputs.py
+++ b/libraries/dagster-delta/dagster_delta_tests/test_metadata_inputs.py
@@ -23,7 +23,11 @@ def io_manager(tmp_path) -> DeltaLakePyarrowIOManager:
 
 @op(
     out=Out(
-        metadata={"schema": "a_df", "mode": "append", "custom_metadata": {"userName": "John Doe"}},
+        metadata={
+            "schema": "a_df",
+            "mode": "append",
+            "commit_properties": {"custom_metadata": {"userName": "John Doe"}},
+        },
     ),
 )
 def a_df() -> pa.Table:
@@ -61,7 +65,7 @@ def io_manager_with_writer_metadata(tmp_path) -> DeltaLakePyarrowIOManager:
         root_uri=str(tmp_path),
         storage_options=LocalConfig(),
         writer_engine=WriterEngine.rust,
-        custom_metadata={"userName": "John Doe"},
+        commit_properties={"custom_metadata": {"userName": "John Doe"}},
         writer_properties={"compression": "ZSTD"},
     )
 

--- a/libraries/dagster-delta/dagster_delta_tests/test_type_handler.py
+++ b/libraries/dagster-delta/dagster_delta_tests/test_type_handler.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from datetime import datetime
 
 import pyarrow as pa
@@ -9,6 +10,7 @@ from dagster import (
     AssetKey,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
+    ExperimentalWarning,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     Out,
@@ -24,6 +26,8 @@ from dagster._check import CheckError
 from deltalake import DeltaTable
 
 from dagster_delta import DELTA_DATE_FORMAT, DeltaLakePyarrowIOManager, LocalConfig
+
+warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
 
 @pytest.fixture()
@@ -77,6 +81,7 @@ def b_plus_one(b_df: pa.Table) -> pa.Table:
 
 
 def test_deltalake_io_manager_with_assets(tmp_path, io_manager):
+    warnings.filterwarnings("ignore", category=ExperimentalWarning)
     resource_defs = {"io_manager": io_manager}
 
     # materialize asset twice to ensure that tables get properly deleted
@@ -130,6 +135,7 @@ def b_plus_one_columns(b_df: pa.Table) -> pa.Table:
 
 
 def test_loading_columns(tmp_path, io_manager):
+    warnings.filterwarnings("ignore", category=ExperimentalWarning)
     resource_defs = {"io_manager": io_manager}
 
     # materialize asset twice to ensure that tables get properly deleted
@@ -236,6 +242,7 @@ def load_partitioned(daily_partitioned: pa.Table) -> pa.Table:
 
 
 def test_load_partitioned_asset(io_manager):
+    warnings.filterwarnings("ignore", category=ExperimentalWarning)
     resource_defs = {"io_manager": io_manager}
 
     res = materialize(

--- a/libraries/dagster-delta/pyproject.toml
+++ b/libraries/dagster-delta/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "dagster-delta"
-version = "0.1.5"
+version = "0.2.0"
 description = "base deltalake IO Managers for Dagster"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "dagster",
-    "deltalake",
+    "dagster>=1.8,<2.0",
+    "deltalake>=0.24",
 ]
 authors = [{name = "Ion Koutsouris"}]
 license = { file = "licenses/LICENSE" }

--- a/libraries/dagster-unity-catalog-polars/pyproject.toml
+++ b/libraries/dagster-unity-catalog-polars/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-unity-catalog-polars"
-version = "0.1.5"
+version = "0.2.0"
 description = "Polars Unity Catalog IO Managers for Dagster"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
- Resolved all deprecations in the code base
- Sets writer engine to Rust as default to mimic deltalake behavior
- Returns pa.Table instead of reader in to_arrow() for preparation of release 0.24.1 in deltalake
- Deprecates lakefs IO Manager since there is native support now
- Handles lakefs uri to lakefs link conversion