### PR TITLE
Feat: support returning lazyframes

### DIFF
--- a/libraries/dagster-unity-catalog-polars/dagster_unity_catalog_polars/unity_catalog_iomanager.py
+++ b/libraries/dagster-unity-catalog-polars/dagster_unity_catalog_polars/unity_catalog_iomanager.py
@@ -83,8 +83,8 @@ class DatabricksUnityCatalogInputManager(ConfigurableIOManager):
         predicate = metadata.get("predicate")
         partition_predicate = None
         if context.has_asset_partitions:
-            partitions = context._asset_partitions_subset.subset  # type: ignore
-            if len(partitions) > 1:
+            partitions = context._asset_partitions_subset.get_partition_keys()  # type: ignore
+            if len(partitions) > 1:  # type: ignore
                 partition_predicate = f"{metadata['partition_expr']} in {str(tuple(partitions))}"
             else:
                 partition_predicate = f'{metadata["partition_expr"]} == "{list(partitions)[0]}"'

--- a/libraries/dagster-unity-catalog-polars/pyproject.toml
+++ b/libraries/dagster-unity-catalog-polars/pyproject.toml
@@ -5,10 +5,10 @@ description = "Polars Unity Catalog IO Managers for Dagster"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "dagster",
+    "dagster>=1.11",
     "databricks-sdk>=0.40.0",
-    "databricks-sql-connector>=3.7.0",
-    "polars",
+    "databricks-sql-connector>=4.0.0",
+    "polars>=1.30",
     "pydantic>=2.9.2",
 ]
 authors = [


### PR DESCRIPTION
Added support to return `pl.LazyFrame`.

This doesn't add support for streaming read operations since this is still based on the `databricks-sql-connector` for Python, which is still based on Databricks REST API, which doesn't support a Arrow C Stream.

This does allow to request input objects as `pl.LazyFrame` even though all the data is already loaded into memory, thus supporting lazy execution downstream.