### PR TITLE
Fix pyright issues and improve type safety in Dagster Delta

### DIFF
--- a/libraries/dagster-delta/dagster_delta/_db_io_manager/custom_db_io_manager.py
+++ b/libraries/dagster-delta/dagster_delta/_db_io_manager/custom_db_io_manager.py
@@ -13,10 +13,10 @@ try:
         TimeWindowPartitionsDefinition,
     )
 except ModuleNotFoundError:
-    from dagster._core.definitions.multi_dimensional_partitions import (
+    from dagster._core.definitions.multi_dimensional_partitions import (  # pyright: ignore[reportMissingImports]
         MultiPartitionsDefinition,
     )
-    from dagster._core.definitions.time_window_partitions import (
+    from dagster._core.definitions.time_window_partitions import (  # pyright: ignore[reportMissingImports]
         TimeWindowPartitionsDefinition,
     )
 

--- a/libraries/dagster-delta/dagster_delta/_db_io_manager/utils.py
+++ b/libraries/dagster-delta/dagster_delta/_db_io_manager/utils.py
@@ -15,7 +15,7 @@ from dagster import (
 try:
     from dagster._core.definitions.partitions.utils import TimeWindow
 except ModuleNotFoundError:
-    from dagster._core.definitions.time_window_partitions import TimeWindow
+    from dagster._core.definitions.time_window_partitions import TimeWindow  # pyright: ignore[reportMissingImports]
 
 from dagster._core.storage.db_io_manager import TablePartitionDimension
 from pendulum import instance as pdi

--- a/libraries/dagster-delta/dagster_delta/_handler/base.py
+++ b/libraries/dagster-delta/dagster_delta/_handler/base.py
@@ -168,6 +168,7 @@ class DeltalakeBaseArrowTypeHandler(DbTypeHandler[T], Generic[T]):
         logger.debug("Writing with mode: `%s`", main_save_mode)
 
         merge_stats = None
+        partition_filters = None
         partition_columns = None
         predicate = None
 

--- a/libraries/dagster-delta/dagster_delta/_handler/utils/date_format.py
+++ b/libraries/dagster-delta/dagster_delta/_handler/utils/date_format.py
@@ -11,7 +11,7 @@ try:
         TimeWindowPartitionsDefinition,
     )
 except ModuleNotFoundError:
-    from dagster._core.definitions.time_window_partitions import (
+    from dagster._core.definitions.time_window_partitions import (  # pyright: ignore[reportMissingImports]
         TimeWindowPartitionsDefinition,
     )
 

--- a/libraries/dagster-delta/dagster_delta/_handler/utils/dnf.py
+++ b/libraries/dagster-delta/dagster_delta/_handler/utils/dnf.py
@@ -6,7 +6,7 @@ try:
         TimeWindow,
     )
 except ImportError:
-    from dagster._core.definitions.time_window_partitions import (
+    from dagster._core.definitions.time_window_partitions import (  # pyright: ignore[reportMissingImports]
         TimeWindow,
     )
 

--- a/libraries/dagster-delta/dagster_delta/io_manager/arrow.py
+++ b/libraries/dagster-delta/dagster_delta/io_manager/arrow.py
@@ -43,7 +43,7 @@ class _DeltaLakePyArrowTypeHandler(DeltalakeBaseArrowTypeHandler[ArrowTypes]):  
     def to_arrow(
         self,
         obj: Union[ArrowStreamExportable, ArrowArrayExportable],
-    ) -> ArrowStreamExportable:  # noqa: D102
+    ) -> RecordBatchReader:  # noqa: D102
         return RecordBatchReader.from_arrow(obj)
 
     def get_output_stats(self, obj: ArrowTypes) -> dict[str, dg.MetadataValue]:  # noqa: ARG002 # type: ignore

--- a/libraries/dagster-delta/dagster_delta/io_manager/base.py
+++ b/libraries/dagster-delta/dagster_delta/io_manager/base.py
@@ -12,7 +12,7 @@ from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 try:
     from dagster._core.definitions.partitions.utils import TimeWindow
 except ModuleNotFoundError:
-    from dagster._core.definitions.time_window_partitions import TimeWindow
+    from dagster._core.definitions.time_window_partitions import TimeWindow  # pyright: ignore[reportMissingImports]
 
 from dagster._core.storage.db_io_manager import (
     DbClient,

--- a/libraries/dagster-delta/dagster_delta/io_manager/polars.py
+++ b/libraries/dagster-delta/dagster_delta/io_manager/polars.py
@@ -19,6 +19,7 @@ except ImportError as e:
         "Please install dagster-delta[polars]",
     ) from e
 from arro3.core import RecordBatchReader, Table
+from arro3.core.types import ArrowArrayExportable, ArrowStreamExportable
 from dagster import InputContext, MetadataValue, OutputContext
 from dagster._core.storage.db_io_manager import (
     DbTypeHandler,
@@ -37,7 +38,7 @@ PolarsTypes = Union[pl.DataFrame, pl.LazyFrame]
 class _DeltaLakePolarsTypeHandler(DeltalakeBaseArrowTypeHandler[PolarsTypes]):  # noqa: D101
     def from_arrow(  # noqa: D102
         self,
-        obj: Union[RecordBatchReader, Table],
+        obj: Union[ArrowStreamExportable, ArrowArrayExportable],
         target_type: type[PolarsTypes],
     ) -> PolarsTypes:
         raise NotImplementedError


### PR DESCRIPTION
**Bug Fixes**

* Fixed a potential PossiblyUnboundVariable issue in base.py by initializing partition_filters at the beginning of the handle_output method.

**Type Safety Improvements**

* Aligned method signatures of _DeltaLakePyArrowTypeHandler and _DeltaLakePolarsTypeHandler with the base class DeltalakeBaseArrowTypeHandler.

This resolves Pyright errors caused by incompatible method overrides.

* Added Pyright ignore directives for legacy Dagster import paths that are still required for backward compatibility.

* This prevents false-positive static analysis errors when running against newer Dagster versions.

**Verification Tests**

Ran the full test suite; all tests passed successfully (55/55):

`uv run pytest libraries/dagster-delta/dagster_delta_tests`

**Static Analysis**

Ran Pyright across the entire repository with zero reported errors:

`uv run pyright .`
