### PR TITLE
fix: make tests compatible with deltalake>=1.2.1 and fix release workflow

### DIFF
--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build
         working-directory: ${{ inputs.working_directory }}
-        run: uv build
+        run: uv build --out-dir dist
 
       - name: Validate release version
         run: python .github/validate-release-version.py ${{ inputs.working_directory }}/dist ${{ github.ref_name }}

--- a/libraries/dagster-delta/dagster_delta_tests/polars/test_type_handler.py
+++ b/libraries/dagster-delta/dagster_delta_tests/polars/test_type_handler.py
@@ -63,11 +63,11 @@ def test_deltalake_io_manager_with_ops(tmp_path, io_manager):
         dt = DeltaTable(os.path.join(tmp_path, "a_df/result"))
 
         out_df = QueryBuilder().register("tbl", dt).execute("select * from tbl").read_all()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "add_one/result"))
         out_df = QueryBuilder().register("tbl", dt).execute("select * from tbl").read_all()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
 
 @asset(key_prefix=["my_schema"])
@@ -115,11 +115,11 @@ def test_deltalake_io_manager_with_assets(
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/" + asset1_path))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/" + asset2_path))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
 
 def test_deltalake_io_manager_with_schema(tmp_path):
@@ -146,11 +146,11 @@ def test_deltalake_io_manager_with_schema(tmp_path):
 
         dt = DeltaTable(os.path.join(tmp_path, "custom_schema/my_df"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "custom_schema/my_df_plus_one"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
 
 @asset(key_prefix=["my_schema"], ins={"b_df": AssetIn("b_df", metadata={"columns": ["a"]})})
@@ -183,11 +183,11 @@ def test_loading_columns(tmp_path, io_manager, asset1, asset2, asset1_path, asse
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/" + asset1_path))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/" + asset2_path))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
         assert out_df.shape[1] == 1
 

--- a/libraries/dagster-delta/dagster_delta_tests/polars/test_type_handler_save_modes.py
+++ b/libraries/dagster-delta/dagster_delta_tests/polars/test_type_handler_save_modes.py
@@ -74,7 +74,7 @@ def test_deltalake_io_manager_with_ops_appended(tmp_path, io_manager_append):
 
         dt = DeltaTable(os.path.join(tmp_path, "a_df/result"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == expected_result1
+        assert sorted(out_df["a"].to_pylist()) == sorted(expected_result1)
 
         expected_result1.extend(expected_result1)
 
@@ -92,7 +92,7 @@ def test_deltalake_io_manager_with_ops_ignored(tmp_path, io_manager_ignore):
 
         dt = DeltaTable(os.path.join(tmp_path, "a_df/result"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
     dt = DeltaTable(os.path.join(tmp_path, "a_df/result"))
     assert dt.version() == 0

--- a/libraries/dagster-delta/dagster_delta_tests/test_type_handler.py
+++ b/libraries/dagster-delta/dagster_delta_tests/test_type_handler.py
@@ -87,11 +87,11 @@ def test_deltalake_io_manager_with_assets(tmp_path, io_manager):
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/b_df"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/b_plus_one"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
 
 def test_deltalake_io_manager_with_schema(tmp_path):
@@ -118,11 +118,11 @@ def test_deltalake_io_manager_with_schema(tmp_path):
 
         dt = DeltaTable(os.path.join(tmp_path, "custom_schema/my_df"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "custom_schema/my_df_plus_one"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
 
 @asset(key_prefix=["my_schema"], ins={"b_df": AssetIn("b_df", metadata={"columns": ["a"]})})
@@ -140,11 +140,11 @@ def test_loading_columns(tmp_path, io_manager):
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/b_df"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert sorted(out_df["a"].to_pylist()) == [1, 2, 3]
 
         dt = DeltaTable(os.path.join(tmp_path, "my_schema/b_plus_one_columns"))
         out_df = dt.to_pyarrow_table()
-        assert out_df["a"].to_pylist() == [2, 3, 4]
+        assert sorted(out_df["a"].to_pylist()) == [2, 3, 4]
 
         assert out_df.shape[1] == 1
 

--- a/libraries/dagster-delta/pyproject.toml
+++ b/libraries/dagster-delta/pyproject.toml
@@ -162,7 +162,7 @@ convention = "google"
 [dependency-groups]
 dev = [
     "polars>=1.37.0",
-    "deltalake<=1.2.0",
+    "deltalake>=1.2.1",
     "pyarrow<=18.0.0",
     "pyright==1.1.393",
     "pytest>=8.3.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dagster-unity-catalog-polars = { workspace = true }
 
 dev = [
     "polars>=1.37.0",
-    "deltalake<=1.2.0",
+    "deltalake>=1.2.1",
     "pyarrow<=18.0.0",
     "pyright==1.1.393",
     "pytest>=8.3.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -327,7 +327,7 @@ provides-extras = ["polars"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "deltalake", specifier = "<=1.2.0" },
+    { name = "deltalake", specifier = ">=1.2.1" },
     { name = "polars", specifier = ">=1.37.0" },
     { name = "pyarrow", specifier = "<=18.0.0" },
     { name = "pyright", specifier = "==1.1.393" },
@@ -362,7 +362,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "deltalake", specifier = "<=1.2.0" },
+    { name = "deltalake", specifier = ">=1.2.1" },
     { name = "polars", specifier = ">=1.37.0" },
     { name = "pyarrow", specifier = "<=18.0.0" },
     { name = "pyright", specifier = "==1.1.393" },
@@ -469,20 +469,20 @@ wheels = [
 
 [[package]]
 name = "deltalake"
-version = "1.2.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arro3-core" },
     { name = "deprecated" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/fa/e9d5296197158d4231164f28732e64aa4d2ba6ba2c80350e2be83648d3f6/deltalake-1.2.0.tar.gz", hash = "sha256:cfcd1b7b89cd8aeb80d4781d33e69d1323aa51313d76410380fc43cfbd2ef5cb", size = 5133658, upload-time = "2025-10-13T22:06:41.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/5f/095796d6e175103924989157bfab537efe41806b2b706b76df86051ded2c/deltalake-1.4.2.tar.gz", hash = "sha256:957e52624e1dcee35f0920868e3d15a1feab40fcd0fcd4682231a33da3d442da", size = 5246550, upload-time = "2026-02-09T03:15:57.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/31/d59c41ae45e3e4929c063c7157a6bbf5c19f617994a2f44a349ab579a905/deltalake-1.2.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f55978df37b5ec2a8b31c91cdde75c8a5d5deddee09e67b70b1d432d786cf261", size = 47086820, upload-time = "2025-10-13T22:08:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/19/2169d02f761930867b72903d9ba3deafeb49c4ad1c9028aef4577f3754e9/deltalake-1.2.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0a576be30837216ec292bff82bace6d3590e714d726b5b77854e21ea881f0f37", size = 43284822, upload-time = "2025-10-13T22:08:36.082Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a1/2bba7a964b18f292a14f13f8d35b18b58cb85a5f176fb12f4c70236d7106/deltalake-1.2.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dead236f5bd0fc71bd1fbe31cda7a305be0abce3f651c07bf585b765783e5ae", size = 56649067, upload-time = "2025-10-13T22:06:37.725Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/2c/fc6d1a7da1857b3c58608a032bf93f7fe778d198fbff5e69be67cba52a63/deltalake-1.2.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e29de2431c62df3b6297cd2ccd67a1ca432dd9625273f17659f88a85306b3b9", size = 45352119, upload-time = "2025-10-13T22:07:43.855Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/26/a1d8b9d41e0085cbbab1e472fb0bb896a62c582f58a06c21edfd0277fd4d/deltalake-1.2.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6cab5ed781c8aa61b1663bcbf15c3a2811804dd41ebbc57e5e3b17c7fbf3d071", size = 49169718, upload-time = "2025-10-13T22:07:48.271Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/49/18c78414e33096b17ef3b924110775cebd278543153d1f098969f5ccee9e/deltalake-1.2.0-cp39-abi3-win_amd64.whl", hash = "sha256:b5bd1caafaa9fe8343338986fe99e22d3dfc54ed2c0c10518a7dcadef9cc0067", size = 47945301, upload-time = "2025-10-13T22:23:02.018Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/c2835de7bfbf810849cc6d48720574dd7f5ce308e5d11ab5d9bbaa8afb4e/deltalake-1.4.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5c88b856a74517abfc91ca667594e984648447ba96e65914db2190467caad9b9", size = 37692216, upload-time = "2026-02-09T03:36:36.034Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/9b/ddb4adaec71b42c172905764d945b0ed01db1167cb59ec347f08d9456e31/deltalake-1.4.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4d4044a83e13a861c1d94eb5211dc40f41d089c9d6db9c08445d0438d346fe3", size = 34600691, upload-time = "2026-02-09T03:36:05.443Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ec/9aa7d0c52355d4664fcc1552a0be7535111f15003d2cd1cd8f225a256622/deltalake-1.4.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b6817e8beae1408fc90827c5c3687d5acf35ae9e43a0e71e5c517a6ec77272a", size = 38490480, upload-time = "2026-02-09T03:15:53.185Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d4/d70be4042a4818b906e9e1f55504b205eb94f48696b568b7e33a989d3cf1/deltalake-1.4.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c6e4797bb0b3e9fd62cbe41806f52f68658891528ee4b6a2073d16c2002bdcc8", size = 37146247, upload-time = "2026-02-09T03:06:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/74/bc63508d0ea80b9cb52db9844ba044fd11a7dff235093eae74a13cc0ff25/deltalake-1.4.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f515fd0ecfcd87ba7dfa3fd94247e1fd8f0ce147e1bd78e2d7a32197ce5dbf17", size = 38486927, upload-time = "2026-02-09T03:16:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e0/e15a10c860e9a773bf0ac951a8bb8491a115a77e22ae52a5cbc1d13d9594/deltalake-1.4.2-cp310-abi3-win_amd64.whl", hash = "sha256:2e3e6f858ddf843a3f6936d7261866a765408c253e31483172f8c28600cc55ff", size = 40774527, upload-time = "2026-02-09T03:39:48.583Z" },
 ]
 
 [[package]]
@@ -568,6 +568,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/6a/33d1702184d94106d3cdd7bfb788e19723206fce152e303473ca3b946c7b/greenlet-3.3.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6f8496d434d5cb2dce025773ba5597f71f5410ae499d5dd9533e0653258cdb3d", size = 273658, upload-time = "2025-12-04T14:23:37.494Z" },
     { url = "https://files.pythonhosted.org/packages/d6/b7/2b5805bbf1907c26e434f4e448cd8b696a0b71725204fa21a211ff0c04a7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b96dc7eef78fd404e022e165ec55327f935b9b52ff355b067eb4a0267fc1cffb", size = 574810, upload-time = "2025-12-04T14:50:04.154Z" },
     { url = "https://files.pythonhosted.org/packages/94/38/343242ec12eddf3d8458c73f555c084359883d4ddc674240d9e61ec51fd6/greenlet-3.3.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73631cd5cccbcfe63e3f9492aaa664d278fda0ce5c3d43aeda8e77317e38efbd", size = 586248, upload-time = "2025-12-04T14:57:39.35Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/0ae86792fb212e4384041e0ef8e7bc66f59a54912ce407d26a966ed2914d/greenlet-3.3.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b299a0cb979f5d7197442dccc3aee67fce53500cd88951b7e6c35575701c980b", size = 597403, upload-time = "2025-12-04T15:07:10.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/a8/15d0aa26c0036a15d2659175af00954aaaa5d0d66ba538345bd88013b4d7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dee147740789a4632cace364816046e43310b59ff8fb79833ab043aefa72fd5", size = 586910, upload-time = "2025-12-04T14:25:59.705Z" },
     { url = "https://files.pythonhosted.org/packages/e1/9b/68d5e3b7ccaba3907e5532cf8b9bf16f9ef5056a008f195a367db0ff32db/greenlet-3.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:39b28e339fc3c348427560494e28d8a6f3561c8d2bcf7d706e1c624ed8d822b9", size = 1547206, upload-time = "2025-12-04T15:04:21.027Z" },
     { url = "https://files.pythonhosted.org/packages/66/bd/e3086ccedc61e49f91e2cfb5ffad9d8d62e5dc85e512a6200f096875b60c/greenlet-3.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3c374782c2935cc63b2a27ba8708471de4ad1abaa862ffdb1ef45a643ddbb7d", size = 1613359, upload-time = "2025-12-04T14:27:26.548Z" },
@@ -575,6 +576,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -582,6 +584,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -589,6 +592,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -596,6 +600,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -603,6 +608,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },


### PR DESCRIPTION
Closes #48

## Summary

- Updated test assertions to handle Arrow chunk layout, row ordering, and `string_view` type differences introduced in newer `deltalake` versions
- Updated `pyproject.toml` as mentioned
- Fixed release workflow `uv build` to use `--out-dir dist` so artifacts land where validation and publish steps expect them, deployment should not fail now

## Details

**Test fixes (closes #48):**
- Normalized PyArrow table comparisons via `pa.table(t.to_pydict())` to handle `string_view` vs `string` type mismatches and chunk differences and used `sorted()` on `to_pylist()` results for order-independent value assertions
- Aligned column ordering in assertions where partition columns shift position

**Release workflow fix:**
`uv build` in a workspace writes artifacts to repo-root `dist/` by default, but `validate-release-version.py` and `uv publish` expect them in `${{ inputs.working_directory }}/dist` so added `--out-dir dist` to the build step in `template-release.yml` and its solved

Fixes were tested locally as well
