### PR TITLE
fix monthly time window partitions with multi-dimensional partitions 

### DIFF
--- a/libraries/dagster-delta/dagster_delta/_db_io_manager/utils.py
+++ b/libraries/dagster-delta/dagster_delta/_db_io_manager/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from itertools import accumulate
 from typing import List, Mapping, Sequence, Union, cast  # noqa
 
 import pendulum
@@ -128,10 +129,10 @@ class MultiTimePartitionsChecker:
         self.end = end_date
 
     @property
-    def hourly_delta(self) -> List[int]:
+    def hourly_delta(self) -> list[int]:
         # de-duplicate partitions while preserving order
         partitions = list(dict.fromkeys(self._partitions).keys())
-        
+
         deltas = [date_diff(w.start, w.end).in_hours() for w in partitions]
         deltas_months = [date_diff(w.start, w.end).in_months() for w in partitions]
         condition = (len(set(deltas)) != 1) and (len(set(deltas_months)) != 1)
@@ -143,16 +144,15 @@ class MultiTimePartitionsChecker:
 
     def is_consecutive(self) -> bool:
         """Checks whether the provided start dates of each partition timewindow is consecutive"""
-        if len(set(self.hourly_delta)) == 1: 
+        if len(set(self.hourly_delta)) == 1:
             expected_starts = {
-            pdi(self.start).add(hours=self.hourly_delta[0] * i)
-            for i in range(len(set(self._partitions)))
-        } 
+                pdi(self.start).add(hours=self.hourly_delta[0] * i)
+                for i in range(len(set(self._partitions)))
+            }
         else:
             delta_hours = [0, *accumulate(self.hourly_delta[:-1])]
             expected_starts = {
-                pdi(self.start).add(hours=h)
-                for h in delta_hours[: len(set(self._partitions))]
+                pdi(self.start).add(hours=h) for h in delta_hours[: len(set(self._partitions))]
             }
 
         actual_starts = {pdi(d.start) for d in self._partitions}

--- a/libraries/dagster-delta/dagster_delta_tests/_db_io_manager/test_db_io_manager_utils.py
+++ b/libraries/dagster-delta/dagster_delta_tests/_db_io_manager/test_db_io_manager_utils.py
@@ -98,7 +98,7 @@ def test_multi_time_partitions_monthly_checker(
         partitions=monthly_partitions_time_window,
     )
 
-    assert checker.hourly_delta == 744
+    assert checker.hourly_delta == [744]
     assert checker.start == dt.datetime(2022, 1, 1, 0)
     assert checker.end == dt.datetime(2022, 2, 1, 0)
     assert checker.is_consecutive()
@@ -111,7 +111,7 @@ def test_multi_time_partitions_daily_checker_consecutive(
         partitions=daily_partitions_time_window_consecutive,
     )
 
-    assert checker.hourly_delta == 24
+    assert checker.hourly_delta == [24, 24, 24]
     assert checker.start == dt.datetime(2022, 1, 1, 0)
     assert checker.end == dt.datetime(2022, 1, 4, 0)
     assert checker.is_consecutive()
@@ -124,7 +124,7 @@ def test_multi_time_partitions_daily_checker_non_consecutive(
         partitions=daily_partitions_time_window_not_consecutive,
     )
 
-    assert checker.hourly_delta == 24
+    assert checker.hourly_delta == [24, 24, 24]
     assert checker.start == dt.datetime(2022, 1, 1, 0)
     assert checker.end == dt.datetime(2022, 1, 5, 0)
     assert not checker.is_consecutive()
@@ -137,7 +137,7 @@ def test_multi_time_partitions_hourly_checker_consecutive(
         partitions=hourly_partitions_time_window_consecutive,
     )
 
-    assert checker.hourly_delta == 1
+    assert checker.hourly_delta == [1, 1, 1]
     assert checker.start == dt.datetime(2022, 1, 1, 1)
     assert checker.end == dt.datetime(2022, 1, 1, 4)
     assert checker.is_consecutive()
@@ -150,7 +150,7 @@ def test_multi_time_partitions_hourly_checker_non_consecutive(
         partitions=hourly_partitions_time_window_not_consecutive,
     )
 
-    assert checker.hourly_delta == 1
+    assert checker.hourly_delta == [1, 1, 1]
     assert checker.start == dt.datetime(2022, 1, 1, 1)
     assert checker.end == dt.datetime(2022, 1, 1, 5)
     assert not checker.is_consecutive()


### PR DESCRIPTION
Assets with monthly timewindow partitions were failing as  `generate_multi_partitions_dimension`  expected all partitions to have the same time delta, which is fine for hourly or weekly partitions, however for monthly partitions this does not work as months have differing lengths. 

Fix involves adding a second check looking for monthly intervals in `hourly_delta`. Additionally, as the delta (in hours) from the start to end of a partition is not necessarily the same for each partition anymore, `hourly_delta` now returns a list of the hourly delta in every partition rather than just the hourly delta of the first partition (this would have worked in the past as every partition would have identical hourly delta).
